### PR TITLE
Fix #17: UI forbedringer - fjern sidebar og flyt sprogvælger

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,58 @@
+---
+description: "Kør TDD-loop på et issue: git branch, skriv tests, udfør parallelt arbejde med agenter, kør tests, iterer"
+argument-hint: [Issue #]
+allowed-tools: Bash(git status:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(pnpm test:*), Bash(pnpm run:*), Read, Write, Grep, Glob
+---
+
+# Byggeproces for $1
+
+1. **Git setup**
+   - Tjek ud fra `main`, træk seneste:
+     ```bash
+     git checkout main
+     git pull --ff-only
+     ```
+   - Opret feature-branch baseret på issue:
+     ```bash
+     git checkout -b [type]/[issue-no]-[description]
+     ```
+
+2. **Læs issuel**
+   - Læs issue #`$1` ved hjælp af GH CLI og udtræk:
+     - Accept-kriterier
+     - Tasks opdelt i UI / backend / tests / audio
+   - Marker hvilke tasks der kan køres parallelt.
+
+3. **Skriv tests først**
+   - Send acceptance til `test-writer` subagent → generér Vitest/Playwright skeletons.
+   - Gem filer og kør:
+     ```bash
+     pnpm test
+     ```
+   - Bekræft at tests fejler.
+
+4. **Udfør arbejdet parallelt**
+   - UI-tasks → `audio-engineer` subagent.
+   - Backend-tasks → `backend-surgeon` subagent.
+   - Testrelateret → `test-writer` fortsætter.
+   - Hver agent skriver kode i egne filer, commit småt:
+     ```bash
+     git add -A
+     git commit -m "wip($1): partial implementation"
+     ```
+
+5. **Kør tests**
+   - Gentag:
+     ```bash
+     pnpm test
+     ```
+   - Hvis rødt → iterér: bed relevante subagent justere.
+
+6. **Afslut**
+   - Når alle tests grønne:
+     ```bash
+     git add -A
+     git commit -m "[type]($1): implement tasks til grøn suite"
+     git push -u origin HEAD
+     ```
+   - Udskriv: "Issue #$1 fuldført, alle tests grønne, branch klar til PR."

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,7 +13,6 @@ import { useRouter } from 'next/navigation';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Settings } from '@podcast-studio/shared';
 import { Card } from '../ui/Card';
-import { Sidebar } from '../components/Sidebar';
 import { Modal } from '../ui/Modal';
 import { TopBar } from '../components/TopBar';
 
@@ -152,11 +151,7 @@ export default function HomePage() {
           onMuteToggle={setMute}
         />
       </div>
-      <div className="mx-auto max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div>
-          <Sidebar current="home" />
-        </div>
-        <div className="space-y-6 lg:col-span-2">
+      <div className="mx-auto max-w-7xl space-y-6">
           {currentSettings && <CurrentSettings settings={currentSettings} />}        
 
           <Card header={<h2 className="text-xl font-semibold">{t.transcript.title}</h2>}>
@@ -168,7 +163,6 @@ export default function HomePage() {
               <SessionHistory onResumeSession={handleResumeSession} currentSessionId={currentSessionId || undefined} />
             </Card>
           )}
-        </div>
       </div>
 
       <Modal open={settingsOpen} onClose={() => setSettingsOpen(false)} title={t.settings.title}>

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -23,7 +23,7 @@ interface TopBarProps {
 }
 
 export function TopBar(props: TopBarProps) {
-  const { t } = useLanguage();
+  const { t, language, setLanguage } = useLanguage();
   const { status, isRecording, paused, isAiSpeaking = false } = props;
 
   const connColor =
@@ -119,6 +119,28 @@ export function TopBar(props: TopBarProps) {
 
       {/* Right: Icons */}
       <div className="flex items-center gap-2">
+        {/* Language selector */}
+        <div className="flex gap-1 bg-elevated rounded-full p-1">
+          <button
+            onClick={() => setLanguage('da')}
+            className={`px-3 py-1 rounded-full text-sm transition-ui ${
+              language === 'da' ? 'bg-[var(--accent)] text-white' : 'text-ink hover:bg-elevated/50'
+            }`}
+            aria-label="Dansk"
+          >
+            DA
+          </button>
+          <button
+            onClick={() => setLanguage('en')}
+            className={`px-3 py-1 rounded-full text-sm transition-ui ${
+              language === 'en' ? 'bg-[var(--accent)] text-white' : 'text-ink hover:bg-elevated/50'
+            }`}
+            aria-label="English"
+          >
+            EN
+          </button>
+        </div>
+
         <Tooltip label={t.tooltips.sessions}>
           <button className="p-2 rounded-full bg-elevated hover:bg-elevated/90 transition-ui" onClick={props.onToggleSessions} aria-label={t.toolbar.sessions}>
             <History className="w-5 h-5 text-ink" />


### PR DESCRIPTION
## Summary
- Fjernet "Podcast Studio" sidebar/kort fra hjemmesiden
- Flyttet sprogvælger (DA/EN) til topbaren ved siden af de andre kontroller  
- Forenklet layout fra 3-kolonne grid til enkelt kolonne

## Changes
- Removed `Sidebar` component import and usage from `page.tsx`
- Changed layout from 3-column grid to single column layout
- Added language selector buttons to `TopBar` component
- Integrated `useLanguage` hook in TopBar for language switching

## Testing
- ✅ TypeScript compilation passes
- ✅ UI tested locally - language switcher works in top bar
- ✅ Sidebar successfully removed from homepage

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)